### PR TITLE
Citation: c056

### DIFF
--- a/style_c056.txt
+++ b/style_c056.txt
@@ -1,6 +1,12 @@
 >>===== MODE =====>>
-citation-suppress_trailing_punctuation
+citation
 <<===== MODE =====<<
+
+>>===== OPTIONS =====>>
+{
+    "wrap_url_and_doi": true
+}
+<<===== OPTIONS =====<<
 
 >>===== KEYS =====>>
 [
@@ -9,12 +15,23 @@ citation-suppress_trailing_punctuation
 <<===== KEYS =====<<
 
 >>===== DESCRIPTION =====>>
-Initial test checkin
+Official case names aren't italicized when cited in the full citation for law review articles.
 <<===== DESCRIPTION =====<<
 
 >>===== RESULT =====>>
-<i>United States v. $124,570 U.S. Currency</i>, 873 F.2d 1240 (9th Cir. 1989)
+United States v. $124,570 U.S. Currency, 873 F.2d 1240 (9th Cir. 1989)
 <<===== RESULT =====<<
+
+>>===== CITATION-ITEMS =====>>
+[
+  [
+    {
+      "id": "HY4DYJIZ",
+      "position": 0
+    }
+  ]
+]
+<<===== CITATION-ITEMS =====<<
 
 >>===== INPUT =====>>
 [
@@ -37,15 +54,3 @@ Initial test checkin
   }
 ]
 <<===== INPUT =====<<
-
-
->>===== CITATION-ITEMS =====>>
-[
-  [
-    {
-      "id": "HY4DYJIZ",
-      "position": 0
-    }
-  ]
-]
-<<===== CITATION-ITEMS =====<<


### PR DESCRIPTION
Official case names aren't italicized when cited in the full citation for law review articles.