### PR TITLE
Citation: c079

### DIFF
--- a/style_c079.txt
+++ b/style_c079.txt
@@ -1,5 +1,5 @@
 >>===== MODE =====>>
-citation-suppress_trailing_punctuation
+citation
 <<===== MODE =====<<
 
 >>===== OPTIONS =====>>
@@ -15,11 +15,11 @@ citation-suppress_trailing_punctuation
 <<===== KEYS =====<<
 
 >>===== DESCRIPTION =====>>
-Initial test checkin
+Official case names aren't italicized when cited in the full citation for law review articles.
 <<===== DESCRIPTION =====<<
 
 >>===== RESULT =====>>
-<i>State v. Green</i>, No. 2012AP1475-CR, 2013 WL 5811261, at *7 (Wis. Ct. App. Oct. 30, 2013)
+State v. Green, No. 2012AP1475-CR, 2013 WL 5811261, at *7 (Wis. Ct. App. Oct. 30, 2013)
 <<===== RESULT =====<<
 
 >>===== CITATION-ITEMS =====>>


### PR DESCRIPTION
Official case names aren't italicized when cited in the full citation for law review articles.