### PR TITLE
Citation: c101

### DIFF
--- a/style_c101.txt
+++ b/style_c101.txt
@@ -1,6 +1,12 @@
 >>===== MODE =====>>
-citation-suppress_trailing_punctuation
+citation
 <<===== MODE =====<<
+
+>>===== OPTIONS =====>>
+{
+    "wrap_url_and_doi": true
+}
+<<===== OPTIONS =====<<
 
 >>===== KEYS =====>>
 [
@@ -9,22 +15,22 @@ citation-suppress_trailing_punctuation
 <<===== KEYS =====<<
 
 >>===== DESCRIPTION =====>>
-Initial test checkin
+Official case names aren't italicized when cited in the full citation for law review articles.
 <<===== DESCRIPTION =====<<
 
 >>===== RESULT =====>>
-<i>Fenton v. Quaboag Country Club</i>, 233 N.E.2d 216, 219 (Mass. 1968)
+Fenton v. Quaboag Country Club, 233 N.E.2d 216, 219 (Mass. 1968)
 <<===== RESULT =====<<
 
 >>===== CITATION-ITEMS =====>>
 [
-[
-  {
-    "id": "SR2XRUKU",
-    "position": 0,
-    "locator": "p. 219"
-  }
-]
+  [
+    {
+      "id": "SR2XRUKU",
+      "position": 0,
+      "locator": "p. 219"
+    }
+  ]
 ]
 <<===== CITATION-ITEMS =====<<
 


### PR DESCRIPTION
Official case names aren't italicized when cited in the full citation for law review articles.