### PR TITLE
Citation: c105

### DIFF
--- a/style_c105.txt
+++ b/style_c105.txt
@@ -1,6 +1,12 @@
 >>===== MODE =====>>
-citation-suppress_trailing_punctuation
+citation
 <<===== MODE =====<<
+
+>>===== OPTIONS =====>>
+{
+    "wrap_url_and_doi": true
+}
+<<===== OPTIONS =====<<
 
 >>===== KEYS =====>>
 [
@@ -9,21 +15,21 @@ citation-suppress_trailing_punctuation
 <<===== KEYS =====<<
 
 >>===== DESCRIPTION =====>>
-Initial test checkin
+Official case names aren't italicized when cited in the full citation for law review articles.
 <<===== DESCRIPTION =====<<
 
 >>===== RESULT =====>>
-<i>United States v. Carmel</i>, 548 F.3d 571 (7th Cir. 2008)
+United States v. Carmel, 548 F.3d 571 (7th Cir. 2008)
 <<===== RESULT =====<<
 
 >>===== CITATION-ITEMS =====>>
 [
-[
-  {
-    "id": "2G79JWPS",
-    "position": 0
-  }
-]
+  [
+    {
+      "id": "2G79JWPS",
+      "position": 0
+    }
+  ]
 ]
 <<===== CITATION-ITEMS =====<<
 
@@ -44,6 +50,7 @@ Initial test checkin
         ]
       ]
     },
+    "shortTitle": "Carmel",
     "jurisdiction": "us:c7"
   }
 ]


### PR DESCRIPTION
Official case names aren't italicized when cited in the full citation for law review articles.